### PR TITLE
Fixing tick prio bug

### DIFF
--- a/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
+++ b/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
@@ -92,7 +92,7 @@
   * @{
   */
 __IO uint32_t uwTick;
-uint32_t uwTickPrio   = (1UL << __NVIC_PRIO_BITS); /* Invalid PRIO */
+uint32_t uwTickPrio   = TICK_INT_PRIORITY;
 HAL_TickFreqTypeDef uwTickFreq = HAL_TICK_FREQ_DEFAULT;  /* 1KHz */
 /**
   * @}


### PR DESCRIPTION
When we enabled assertion within the HAL code to call our fw_assert handler, I caught a bug that it seems many people have experienced. When defining the HAL time base to use an hardware timer, you need to re-initialize the Tick value, and the call to HAL_InitTick from within the RCC Clock configure was asserting because it was greater than or equal to the max priority (16 or 0x10). This is simply because the HAL header file sets uwTickPrio to U16, rather than to the TICK_INT_PRIORITY defined in the hal_conf.h file that our application changes.

This bug seems to be documented in multiple places across the st community forum. This is seemingly apparent in our old code (but maybe asymptomatic?) but never caught since we never defined their assert handler.

https://community.st.com/s/question/0D53W00001Az92mSAB/why-assertfailed-in-halinittick
https://community.st.com/s/question/0D50X0000BGvYPsSQN/bug-stm32g474re-assert-issue-when-tim17-is-configurated-as-timebase-source